### PR TITLE
pontrendszer.md: Logic app -> Számítás kategória

### DIFF
--- a/pontrendszer.md
+++ b/pontrendszer.md
@@ -45,8 +45,8 @@
 - Azure Redis cache használata (5 pont)
 - Azure CDN használata (5 pont)
 
-### Alkalmazásmodell (pontosan egy választandó)
-- Azure App Service (API, Web, Mobil, Logic) használata (0 - 11 pont)
+### Alkalmazásmodell
+- Azure App Service (API, Web, Mobil) használata (0 - 11 pont)
     - slot-ok használata (5 pont)
     - App Insights bekötése (3 pont)
     - AutoScale (3 pont)
@@ -56,6 +56,7 @@
 
 ### Számítás
 - Azure Functions használata (7 pont)
+- Azure Logic app használata (5 pont)
 - Azure Batch használata (5 pont)
 - Azure Data Lake Analytics használata (7 pont) - **KÖLTSÉGES lehet!**
     - legalább 10 GB bemenő adat átalakítása vagy analitikai lekérdezése U-SQL-lel. Az előállt eredményt fel kell használni az alkalmazásban.


### PR DESCRIPTION
Habár lehet olyan alkalmazást építeni aminek a vázát Logic App adja, nem ez a szokásos, sokkal inkább hogy egy adott egyszerű feature-t Logic App-en keresztül valósítunk meg. Ezentúl Logic App-et nem lehet App Service-en futtatni, csak mint igazi serveless service (most készül amúgy a Logic app on App Service, Private Preview-ban van), tehát az autoscale-t nem lehet nem beállítani például (ez a serverless lényege). Slotokat sem értelmezünk rajta. 
5 pontot javaslok neki, Functions-nál egyszerűbb dologról van szó, de mégiscsak egy külön feature-t kell írni hogy használni lehessen.

Kivettem a "pontosan egy választandó" megjegyzést az Alkalmazásmodell kategória mögül, simán elképzelhető egy olyan megoldás ahol két PaaS service együtt dolgozik (pl. API és static frontend külön, vagy egy ASP.NET MVC weboldal és egy API a mobilappnak Javaban írva, stb.)
